### PR TITLE
feat(cookiecutter): update cookiecutter defaults

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "project_name": "APIS Sample Instance",
-  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
-  "author": "Anonymous"
+  "project_name": "APIS Instance Cookiecutter",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
+  "module_name": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}"
 }


### PR DESCRIPTION
Set the project name to `APIS Instance Cookiecutter`
Use the dash as a separateor in the `project_slug` and introduce a
separate `module_name` which adheres to the python module name
standards.
