### PR TITLE
feat(cookiecutter): ship a default urls.py

### DIFF
--- a/{{ cookiecutter.project_slug }}/apis_ontology/settings.py
+++ b/{{ cookiecutter.project_slug }}/apis_ontology/settings.py
@@ -1,1 +1,3 @@
 from apis_acdhch_default_settings.settings import *
+
+ROOT_URLCONF = "apis_ontology.urls"

--- a/{{ cookiecutter.project_slug }}/apis_ontology/urls.py
+++ b/{{ cookiecutter.project_slug }}/apis_ontology/urls.py
@@ -1,0 +1,1 @@
+from apis_acdhch_default_settings.urls import urlpatterns


### PR DESCRIPTION
Without shipping a default urls.py that uses the one from
apis_acdhch_default_settings, user might attempt to write the whole
urls.py from scratch, which leads to problems.
